### PR TITLE
Updated package.json dependencies

### DIFF
--- a/data/package.json
+++ b/data/package.json
@@ -5,9 +5,9 @@
     "private": true,
     "dependencies": {
     	"googleclientlogin": "*",
-    	"spotify-web": "*",
+    	"spotify-web": "1.2.0",
     	"socket.io": "*",
-    	"express": "*",
+    	"express": "3.5.1",
     	"superagent": "*",
     	"levenshtein": "*",
     	"timequeue": "*"


### PR DESCRIPTION
Sets hard version dependencies for spotify-web and express, to mirror the fixes I made to get Portify working again. Fixes #96, #99, #80 and probably others.
